### PR TITLE
會員權限設置測試

### DIFF
--- a/app/member/AuthTest/page.js
+++ b/app/member/AuthTest/page.js
@@ -1,0 +1,26 @@
+'use client'
+
+import React, { useState, useEffect } from 'react'
+import { useAuth } from '@/app/context/AuthContext'; // 引入 useAuth
+import { useRouter } from 'next/navigation';// 導向到登入頁面
+//引入 useAuth
+export default function ProtectedPage() {
+  const { user } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!user) {
+      router.push('/member/MemberLogin/login');// 將使用者導向到登入頁面
+    }
+  }, [user, router]);
+
+  if (!user) {
+    return null;
+  }// 如果使用者未登入不顯示任何內容，導向到登入頁面
+
+  return (
+    <div>
+      <h1>放入頁面內容</h1>
+    </div>
+  );
+}

--- a/app/member/MemberLogin/login/page.js
+++ b/app/member/MemberLogin/login/page.js
@@ -61,7 +61,7 @@ export default function MemberPage() {
           showConfirmButton: false,
         });
 
-        router.push('/member');
+        router.push('/member/AuthTest');
       } else {
         await Swal.fire({
           title: '登入失敗',

--- a/app/member/page.js
+++ b/app/member/page.js
@@ -4,18 +4,18 @@
 import React, { useEffect } from 'react';
 import Link from 'next/link';
 import styles from "./member.module.css";
-import { useRouter } from 'next/navigation';
-import { useAuth } from '@/app/context/AuthContext';
+import { useAuth } from '@/app/context/AuthContext'; // 引入 useAuth
+import { useRouter } from 'next/navigation';// 導向到登入頁面
 
 export default function MemberPage() {
   const { user, loading } = useAuth();
   const router = useRouter();
 
   useEffect(() => {
-    if (!loading && !user) {
+    if (!user) {
       router.push('/member/MemberLogin/login');
     }
-  }, [user, loading, router]);
+  }, [user, router]);
 
   const handleNicknameChange = async (event) => {
     const newNickname = event.target.value;


### PR DESCRIPTION
建構好會員權限設置，會員登入會先導入測試頁面。
測試頁面路徑app\member\AuthTest，可參考AuthTest的page.js 進行導入修改，導入後即完成會員驗證。
登入後可在local storage抓取使用者資料。